### PR TITLE
Refine annotation recipe & added custom routing

### DIFF
--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -10,13 +10,34 @@ Example Usage:
 """
 
 from collections.abc import Iterator
+import pathlib
 
 import spacy
 from prodigy import log, set_hashes
 from prodigy.components.preprocess import tokenize_example
 from prodigy.components.stream import get_stream
-from prodigy.core import Arg, recipe
+from prodigy.core import Arg, Controller, recipe
 from prodigy.types import RecipeSettingsType, StreamType
+from prodigy.util import TASK_HASH_ATTR
+
+
+# Mapping of languages to number of required annotations
+LANG2N_ANNOT = {
+    "es": 1,
+    "ja": 2,
+    "pt": 1,
+    "zh": 2,
+}
+
+
+def get_total_examples_target(in_jsonl: pathlib.Path) -> int:
+    """
+    Determines the total number of annotations expected for the given JSONL
+    """
+    n_annot = 0
+    for ex in get_stream(in_jsonl):
+        n_annot += LANG2N_ANNOT[ex["src_lang"]]
+    return n_annot
 
 
 def add_tokens(stream: StreamType) -> Iterator[StreamType]:
@@ -34,8 +55,42 @@ def add_tokens(stream: StreamType) -> Iterator[StreamType]:
 
 
 def add_questions(questions, stream: StreamType) -> Iterator[StreamType]:
+    """
+    Add questions to items in stream
+    """
     for ex in stream:
         yield ex | {"questions": questions}
+
+
+def get_lang_annotators(ctrl: Controller, lang: str) -> list[str]:
+    """
+    Gathers the annotators for a specific language. 
+    """
+    # Get all known session names
+    annotators = ctrl.session_ids
+    return [a for a in annotators if f"-{lang}_" in a]
+
+
+def lang_task_router(ctrl: Controller, session_id: str, item: dict) -> list[str]:
+    """
+    Route tasks based on language and selecting 2 random annotators when possible
+    """
+    # Get source language of item
+    src_lang = item["src_lang"]
+    # Required number of annotations
+    n_annot = LANG2N_ANNOT[src_lang]
+    # Get pool of annotators
+    pool = get_lang_annotators(ctrl, src_lang)
+    # Use hash to select n_annot random, but deterministic annotators
+    task_hash = item[TASK_HASH_ATTR]
+    selected_annotators = []
+    while len(selected_annotators) < n_annot:
+        # If the pool is empty, just return the annotators so far
+        if len(pool) == 0:
+            return selected_annotators
+        i = task_hash % len(pool)
+        selected_annotators.append(pool.pop(i))
+    return selected_annotators
 
 
 @recipe(
@@ -49,6 +104,23 @@ def concept_eval_recipe(
 ) -> RecipeSettingsType:
     # TODO: Consider adding an instruction page. See https://prodi.gy/docs/api-web-app#instructions
     log("RECIPE: Starting recipe concept-eval", locals())
+
+    # Task elements most likely to be modified
+    ## Question prompts for task
+    questions = [
+        "Q1. For the following translation, highlight the translation of the concept",
+        "Q2. Evaluate the machine translation of the concept",
+        "Q3. Notes / observations",
+    ]
+
+    q2_labels  = [
+        {"id": "correct", "text": "Correct"},
+        {"id": "partial", "text": "Partially correct"},
+        {"id": "wrong", "text": "Incorrect"},
+        {"id": "verbatim", "text": "Copied verbatim"},
+        {"id": "missing", "text": "Missing / Omitted"},
+    ]
+
 
     def validate_answer(eg) -> None:
         q1_spans = eg.get("spans", [])
@@ -67,14 +139,8 @@ def concept_eval_recipe(
                 "If the concept was omitted in the translation, no selections should be made for Q1"
             )
 
-    # Question prompts for task
-    questions = [
-        "Q1. For the folloing translation, highlight the translation of the concept",
-        "Q2. Evaluate the machine translation of the concept",
-        "Q3. Notes / observations",
-    ]
-
-    # Initial html template for starting text
+    # Recipe organization
+    ## Initial html template for starting text
     init_html_tmpl = "\n".join(
         [
             "<h2>Concept: {{term}}</h2>",
@@ -86,31 +152,25 @@ def concept_eval_recipe(
             f"<hr><b>{questions[0]}</b>",
         ]
     )
-
-    options = [
-        {"id": "correct", "text": "Correct"},
-        {"id": "partial", "text": "Partially correct"},
-        {"id": "wrong", "text": "Incorrect"},
-        {"id": "verbatim", "text": "Copied verbatim"},
-        {"id": "missing", "text": "Missing / Omitted"},
-    ]
-
+    ## Arrangement of combined interfaces
     blocks = [
         {"view_id": "html", "html_template": init_html_tmpl},
         {"view_id": "ner_manual", "labels": ["CONCEPT"]},
         {"view_id": "html", "html": f"<hr><b>{questions[1]}</b>"},
-        {"view_id": "choice", "text": None, "options": options},
+        {"view_id": "choice", "text": None, "options": q2_labels},
         {"view_id": "html", "html": f"<hr><b>{questions[2]}</b>"},
         {"view_id": "text_input", "field_rows": 3},
     ]
-
-    # Setup config
+    ## Configuration
     config = {
-        "buttons": ["accept", "undo"],  # remove reject and ignore buttons
+        "buttons": ["accept", "reject", "undo"],  # remove ignore button
         "show_flag": True,  # show flag button to mark weird machine translations
         "honor_token_whitespace": True,  # reflect whitespace accurately (e.g. in case of leading/trailing spaces)
         "blocks": blocks,
         "ner_manual_highlight_chars": True,
+        "custom_theme": {"cardMaxWidth": "70%"},
+        "allow_work_stealing": False,
+        "total_examples_target": get_total_examples_target(source),
     }
 
     # Create stream
@@ -132,6 +192,7 @@ def concept_eval_recipe(
         "view_id": "blocks",
         "config": config,
         "validate_answer": validate_answer,
+        "task_router": lang_task_router,
     }
 
     return components

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -9,8 +9,8 @@ Example Usage:
     prodigy concept-eval muse_concepts notion-concept-tasks.jsonl -F annotation_recipes.py
 """
 
-from collections.abc import Iterator
 import pathlib
+from collections.abc import Iterator
 
 import spacy
 from prodigy import log, set_hashes
@@ -19,7 +19,6 @@ from prodigy.components.stream import get_stream
 from prodigy.core import Arg, Controller, recipe
 from prodigy.types import RecipeSettingsType, StreamType
 from prodigy.util import TASK_HASH_ATTR
-
 
 # Mapping of languages to number of required annotations
 LANG2N_ANNOT = {
@@ -64,7 +63,7 @@ def add_questions(questions, stream: StreamType) -> Iterator[StreamType]:
 
 def get_lang_annotators(ctrl: Controller, lang: str) -> list[str]:
     """
-    Gathers the annotators for a specific language. 
+    Gathers the annotators for a specific language.
     """
     # Get all known session names
     annotators = ctrl.session_ids
@@ -113,14 +112,13 @@ def concept_eval_recipe(
         "Q3. Notes / observations",
     ]
 
-    q2_labels  = [
+    q2_labels = [
         {"id": "correct", "text": "Correct"},
         {"id": "partial", "text": "Partially correct"},
         {"id": "wrong", "text": "Incorrect"},
         {"id": "verbatim", "text": "Copied verbatim"},
         {"id": "missing", "text": "Missing / Omitted"},
     ]
-
 
     def validate_answer(eg) -> None:
         q1_spans = eg.get("spans", [])

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -21,6 +21,8 @@ from prodigy.types import RecipeSettingsType, StreamType
 from prodigy.util import TASK_HASH_ATTR
 
 # Mapping of languages to number of required annotations
+## NOTE: Numbers determined by availability of annotators. Ideally, all languages
+##       would require the same number of annotations, but some have <2 annotators.
 LANG2N_ANNOT = {
     "es": 1,
     "ja": 2,


### PR DESCRIPTION
**Associated Issue(s):** N/A

### Changes in this PR

- Added a global variable setting the number of annotations needed for a task by language
- Added custom task routing logic
- Added custom logic for calculating the expected number of annotations for a more accurate "source progress"

### Notes

- Custom logic assumes that the session name has a starting prefix indicating the language e.g., "pt_". The session id adds a prefix before the session name, so we determine the viable sessions (i.e, annotators) for a task by checking if the session_id contains "-[src_lang]_".

### Reviewer Checklist