### PR TITLE
Feature/compute cometkiwi metric

### DIFF
--- a/src/muse/evaluation/evaluate_corpus.py
+++ b/src/muse/evaluation/evaluate_corpus.py
@@ -2,8 +2,8 @@
 Generate CSV containing MT metric scores for machine translation corpus.
 
 This script processes a machine translation corpus (JSONL format) and computes
-evaluation metrics (ChrF and COMET) for each translation. The output is a CSV
-file with columns: tr_id, chrf, comet.
+evaluation metrics (ChrF, COMET, and CometKiwi) for each translation. The output
+is a CSV file with columns: tr_id, chrf, comet, cometkiwi.
 
 Usage:
     evaluate_corpus.py INPUT OUTPUT [--verbose]
@@ -18,7 +18,7 @@ import sys
 import orjsonl
 from tqdm import tqdm
 
-from muse.evaluation.metrics import compute_chrf, compute_comet
+from muse.evaluation.metrics import compute_chrf, compute_comet, compute_cometkiwi
 
 logger = logging.getLogger(__name__)
 
@@ -31,9 +31,9 @@ def evaluate_corpus(
     """
     Compute evaluation metrics for machine translation corpus and save to CSV.
 
-    Reads machine translation records from input JSONL file, computes ChrF and
-    COMET scores for each translation, and writes results to output CSV file
-    with columns: tr_id, chrf, comet.
+    Reads machine translation records from input JSONL file, computes ChrF,
+    COMET, and CometKiwi scores for each translation, and writes results to
+    output CSV file with columns: tr_id, chrf, comet, cometkiwi.
     """
     # Count total records for progress bar
     total_records = sum(1 for _ in orjsonl.stream(input_path))
@@ -41,7 +41,9 @@ def evaluate_corpus(
 
     # Open output CSV file
     with output_path.open("w", newline="") as csvfile:
-        writer = csv.DictWriter(csvfile, fieldnames=["tr_id", "chrf", "comet"])
+        writer = csv.DictWriter(
+            csvfile, fieldnames=["tr_id", "chrf", "comet", "cometkiwi"]
+        )
         writer.writeheader()
 
         # Process each translation record
@@ -62,6 +64,10 @@ def evaluate_corpus(
                 src_text=record["src_text"],
                 ref_text=record["ref_text"],
             )
+            cometkiwi_score = compute_cometkiwi(
+                tr_text=record["tr_text"],
+                src_text=record["src_text"],
+            )
 
             # Write to CSV
             writer.writerow(
@@ -69,6 +75,7 @@ def evaluate_corpus(
                     "tr_id": record["tr_id"],
                     "chrf": chrf_score,
                     "comet": comet_score,
+                    "cometkiwi": cometkiwi_score,
                 }
             )
 

--- a/src/muse/evaluation/metrics.py
+++ b/src/muse/evaluation/metrics.py
@@ -120,7 +120,7 @@ def compute_cometkiwi(
         try:
             model_path = download_model("Unbabel/wmt22-cometkiwi-da")
             LOADED_METRICS["cometkiwi"] = load_from_checkpoint(model_path)
-        except KeyError as e:
+        except KeyError as e:  # download_model catches all exceptions and re-raises as KeyError
             msg = (
                 "Authentication required for CometKiwi model. "
                 "Please:\n"

--- a/src/muse/evaluation/metrics.py
+++ b/src/muse/evaluation/metrics.py
@@ -9,9 +9,11 @@ import contextlib
 import io
 import logging
 import os
+from typing import Any
 
 import evaluate
 import torch
+from comet import download_model, load_from_checkpoint
 
 # Environment variable configuration for PyTorch and HuggingFace libraries
 os.environ["TOKENIZERS_PARALLELISM"] = (
@@ -30,6 +32,7 @@ logging.getLogger("pytorch_lightning.utilities.migration").setLevel(logging.WARN
 LOADED_METRICS = {
     "chrf": None,
     "comet": None,
+    "cometkiwi": None,
 }
 
 
@@ -93,5 +96,83 @@ def compute_comet(
         gpus=gpus,
     )
     score = result["mean_score"]
+
+    return score
+
+
+def compute_cometkiwi(
+    tr_text: str,
+    src_text: str,
+) -> float:
+    """
+    Compute CometKiwi score for a translation using the comet package.
+
+    CometKiwi is a reference-free quality estimation metric that combines COMET
+    with OpenKiwi. Unlike COMET, it does not require a reference translation and
+    evaluates translation quality based only on the source text and machine
+    translation.
+
+    Returns a float in the range [0, 1], where 0 indicates a poor translation
+    and 1 indicates a perfect translation.
+    """
+    # Load model once and cache it
+    if LOADED_METRICS["cometkiwi"] is None:
+        try:
+            # Suppress stdout/stderr during model loading
+            with (
+                contextlib.redirect_stdout(io.StringIO()),
+                contextlib.redirect_stderr(io.StringIO()),
+            ):
+                model_path = download_model("Unbabel/wmt22-cometkiwi-da")
+                LOADED_METRICS["cometkiwi"] = load_from_checkpoint(model_path)
+        except Exception as e:
+            # Check if this is an authentication/gated model error
+            # The comet package wraps authentication errors in a KeyError with
+            # "not supported by COMET" message, so we need to check the cause chain
+            error_msg = str(e).lower()
+
+            # Check the exception cause chain for authentication-related errors
+            is_auth_error = False
+            current = e
+            while current is not None:
+                current_msg = str(current).lower()
+                if any(
+                    keyword in current_msg
+                    for keyword in [
+                        "403",
+                        "gated",
+                        "authentication",
+                        "authorized",
+                        "forbidden",
+                    ]
+                ):
+                    is_auth_error = True
+                    break
+                current = getattr(current, "__cause__", None)
+
+            # Also check if it's the specific "not supported" error from comet
+            # which typically indicates an authentication issue with gated models
+            if "not supported by comet" in error_msg or is_auth_error:
+                msg = (
+                    "Authentication required for CometKiwi model. "
+                    "Please:\n"
+                    "1. Visit https://huggingface.co/Unbabel/wmt22-cometkiwi-da and accept the license\n"
+                    "2. Run: hf auth login\n"
+                    "3. Enter your HuggingFace token when prompted"
+                )
+                raise RuntimeError(msg) from e
+            # Re-raise other errors
+            raise
+
+    model = LOADED_METRICS["cometkiwi"]
+    gpus = 1 if (torch.cuda.is_available() or torch.backends.mps.is_available()) else 0
+
+    # Prepare data in the format expected by CometKiwi
+    data = [{"src": src_text, "mt": tr_text}]
+
+    # Predict returns a Prediction object; access the first score
+    model_output = model.predict(data, batch_size=1, gpus=gpus)
+    # The Prediction object can be indexed to get individual scores
+    score = model_output[0]
 
     return score

--- a/src/muse/evaluation/metrics.py
+++ b/src/muse/evaluation/metrics.py
@@ -9,14 +9,11 @@ import contextlib
 import io
 import logging
 import os
-from pathlib import Path
 from typing import Any
 
 import evaluate
 import torch
-from comet import load_from_checkpoint
-from huggingface_hub import snapshot_download
-from huggingface_hub.errors import GatedRepoError, LocalTokenNotFoundError
+from comet import download_model, load_from_checkpoint
 
 # Environment variable configuration for PyTorch and HuggingFace libraries
 os.environ["TOKENIZERS_PARALLELISM"] = (
@@ -121,10 +118,9 @@ def compute_cometkiwi(
     # Load model once and cache it
     if LOADED_METRICS["cometkiwi"] is None:
         try:
-            model_path = snapshot_download(repo_id="Unbabel/wmt22-cometkiwi-da")
-            checkpoint_path = Path(model_path) / "checkpoints" / "model.ckpt"
-            LOADED_METRICS["cometkiwi"] = load_from_checkpoint(checkpoint_path)
-        except (GatedRepoError, LocalTokenNotFoundError) as e:
+            model_path = download_model("Unbabel/wmt22-cometkiwi-da")
+            LOADED_METRICS["cometkiwi"] = load_from_checkpoint(model_path)
+        except KeyError as e:
             msg = (
                 "Authentication required for CometKiwi model. "
                 "Please:\n"

--- a/src/muse/evaluation/metrics.py
+++ b/src/muse/evaluation/metrics.py
@@ -9,11 +9,14 @@ import contextlib
 import io
 import logging
 import os
+from pathlib import Path
 from typing import Any
 
 import evaluate
 import torch
-from comet import download_model, load_from_checkpoint
+from comet import load_from_checkpoint
+from huggingface_hub import snapshot_download
+from huggingface_hub.errors import GatedRepoError, LocalTokenNotFoundError
 
 # Environment variable configuration for PyTorch and HuggingFace libraries
 os.environ["TOKENIZERS_PARALLELISM"] = (
@@ -118,51 +121,18 @@ def compute_cometkiwi(
     # Load model once and cache it
     if LOADED_METRICS["cometkiwi"] is None:
         try:
-            # Suppress stdout/stderr during model loading
-            with (
-                contextlib.redirect_stdout(io.StringIO()),
-                contextlib.redirect_stderr(io.StringIO()),
-            ):
-                model_path = download_model("Unbabel/wmt22-cometkiwi-da")
-                LOADED_METRICS["cometkiwi"] = load_from_checkpoint(model_path)
-        except Exception as e:
-            # Check if this is an authentication/gated model error
-            # The comet package wraps authentication errors in a KeyError with
-            # "not supported by COMET" message, so we need to check the cause chain
-            error_msg = str(e).lower()
-
-            # Check the exception cause chain for authentication-related errors
-            is_auth_error = False
-            current = e
-            while current is not None:
-                current_msg = str(current).lower()
-                if any(
-                    keyword in current_msg
-                    for keyword in [
-                        "403",
-                        "gated",
-                        "authentication",
-                        "authorized",
-                        "forbidden",
-                    ]
-                ):
-                    is_auth_error = True
-                    break
-                current = getattr(current, "__cause__", None)
-
-            # Also check if it's the specific "not supported" error from comet
-            # which typically indicates an authentication issue with gated models
-            if "not supported by comet" in error_msg or is_auth_error:
-                msg = (
-                    "Authentication required for CometKiwi model. "
-                    "Please:\n"
-                    "1. Visit https://huggingface.co/Unbabel/wmt22-cometkiwi-da and accept the license\n"
-                    "2. Run: hf auth login\n"
-                    "3. Enter your HuggingFace token when prompted"
-                )
-                raise RuntimeError(msg) from e
-            # Re-raise other errors
-            raise
+            model_path = snapshot_download(repo_id="Unbabel/wmt22-cometkiwi-da")
+            checkpoint_path = Path(model_path) / "checkpoints" / "model.ckpt"
+            LOADED_METRICS["cometkiwi"] = load_from_checkpoint(checkpoint_path)
+        except (GatedRepoError, LocalTokenNotFoundError) as e:
+            msg = (
+                "Authentication required for CometKiwi model. "
+                "Please:\n"
+                "1. Visit https://huggingface.co/Unbabel/wmt22-cometkiwi-da and accept the license\n"
+                "2. Run: hf auth login\n"
+                "3. Enter your HuggingFace token when prompted"
+            )
+            raise RuntimeError(msg) from e
 
     model = LOADED_METRICS["cometkiwi"]
     gpus = 1 if (torch.cuda.is_available() or torch.backends.mps.is_available()) else 0

--- a/src/muse/evaluation/metrics.py
+++ b/src/muse/evaluation/metrics.py
@@ -29,7 +29,7 @@ logging.getLogger("pytorch_lightning.utilities.migration").setLevel(logging.WARN
 
 # Cache for loaded metrics to avoid reloading models
 # Note: Caching COMET model requires ~2GB RAM for the wmt22-comet-da model
-LOADED_METRICS = {
+LOADED_METRICS: dict[str, Any] = {
     "chrf": None,
     "comet": None,
     "cometkiwi": None,


### PR DESCRIPTION
**Associated Issue(s):** resolves #52 

### Changes in this PR
_Include all key changes in this pull request_

- Added `compute_cometkiwi()` function to `metrics.py` using the `Unbabel/wmt22-cometkiwi-da` model
- Integrated CometKiwi metric into `evaluate_corpus.py` script; CSV output now includes `cometkiwi` column alongside `chrf` and `comet`
- Added HuggingFace authentication error handling with helpful user guidance for the gated HuggingFace model (--> or should we move this to DeveloperNotes instead?)

### Notes
- First run will download ~2GB model and cache it for subsequent use (Added model caching via `LOADED_METRICS` dictionary to reuse loaded models across evaluations)

### Reviewer Checklist
_Include **discrete** checks that should be done by the reviewer beyond looking through
code and/or file changes. Note that this check list will correspond to tasks within
the PR overview page._

- [ ] Verify `compute_cometkiwi()` function signature matches pattern (takes `tr_text` and `src_text`, returns float)
- [ ] Check that `evaluate_corpus.py` correctly computes and writes CometKiwi scores to CSV
