### PR TITLE
Hotfix/task routing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.1
+
+- Update `concept-eval` recipe to fix cross-session filtering error
+
 ## 0.1.0
 
 - Phase 1 release

--- a/src/muse/__init__.py
+++ b/src/muse/__init__.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2025, Center for Digital Humanities, Princeton University
 # SPDX-License-Identifier: Apache-2.0
 
-__version__ = "0.1"
+__version__ = "0.1.1"
 
 __all__ = ["__version__", "annotation", "evaluation", "parallel_corpus", "translation"]

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -115,6 +115,12 @@ def lang_task_router(ctrl: Controller, session_id: str, item: dict) -> list[str]
 
 
 def session_factory(ctrl: Controller, session_id: str) -> Session:
+    """
+    Custom session factory that loads each annotator's past hashes from the
+    database on session start. This prevents annotators from being served
+    examples they've already answered when auto_exclude_current is set to False
+    to disable cross-session filtering.
+    """
     session_hashes = set()
     total_annotated = 0
     if session_id in ctrl.db:

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -115,12 +115,11 @@ def lang_task_router(ctrl: Controller, session_id: str, item: dict) -> list[str]
 
 
 def session_factory(ctrl: Controller, session_id: str) -> Session:
-    if ctrl.db and isinstance(ctrl.dataset, str) and session_id in ctrl.db:
-        session_hashes = set()
-        total_annotated = 0
-        if session_id in ctrl.db:
-            session_hashes = ctrl.db.get_hashes(session_id, kind=ctrl.exclude_by)
-            total_annotated = ctrl.db.count_dataset(session_id, session=True)
+    session_hashes = set()
+    total_annotated = 0
+    if session_id in ctrl.db:
+        session_hashes = ctrl.db.get_hashes(session_id, kind=ctrl.exclude_by)
+        total_annotated = ctrl.db.count_dataset(session_id, session=True)
 
     ctrl.stream.ensure_queue(session_id)
     session = Session(

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -114,6 +114,29 @@ def lang_task_router(ctrl: Controller, session_id: str, item: dict) -> list[str]
     return annotators
 
 
+def session_factory(ctrl: Controller, session_id: str) -> Session:
+    if ctrl.db and isinstance(ctrl.dataset, str) and session_id in ctrl.db:
+        # Get the history for this session if it exists in the database
+        if ctrl.exclude_by == "task":
+            session_hashes = ctrl.db.get_task_hashes(session_id)
+        else:
+            session_hashes = ctrl.db.get_input_hashes(session_id)
+        total_annotated = ctrl.db.count_dataset(session_id, session=True)
+
+    ctrl.stream.ensure_queue(session_id)
+    session = Session(
+        session_id,
+        ctrl.stream,
+        batch_size=ctrl.batch_size,
+        answered_input_hashes=session_hashes if ctrl.exclude_by == "input" else None,
+        answered_task_hashes=session_hashes if ctrl.exclude_by == "task" else None,
+        total_annotated=total_annotated,
+        target_annotated=ctrl.target_annotated or 0,
+    )
+    ctrl.add_session(session)
+    return session
+
+
 @recipe(
     "concept-eval",
     dataset=Arg(help="Dataset to save answers to"),
@@ -212,6 +235,7 @@ def concept_eval_recipe(
         "custom_theme": {"cardMaxWidth": "70%"},
         "allow_work_stealing": False,
         "show_stats": False,  # removing since accept is the only option
+        "auto_exclude_current": False,  # disable Prodigy's cross-session filter
     }
     ### Add instructions if provided
     if instruct and pathlib.Path(instruct).is_file():
@@ -296,6 +320,7 @@ def concept_eval_recipe(
         "config": config,
         "validate_answer": validate_answer,
         "task_router": lang_task_router,
+        "session_factory": session_factory,
         "progress": progress,
     }
     return components

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -116,12 +116,11 @@ def lang_task_router(ctrl: Controller, session_id: str, item: dict) -> list[str]
 
 def session_factory(ctrl: Controller, session_id: str) -> Session:
     if ctrl.db and isinstance(ctrl.dataset, str) and session_id in ctrl.db:
-        # Get the history for this session if it exists in the database
-        if ctrl.exclude_by == "task":
-            session_hashes = ctrl.db.get_task_hashes(session_id)
-        else:
-            session_hashes = ctrl.db.get_input_hashes(session_id)
-        total_annotated = ctrl.db.count_dataset(session_id, session=True)
+        session_hashes = set()
+        total_annotated = 0
+        if session_id in ctrl.db:
+            session_hashes = ctrl.db.get_hashes(session_id, kind=ctrl.exclude_by)
+            total_annotated = ctrl.db.count_dataset(session_id, session=True)
 
     ctrl.stream.ensure_queue(session_id)
     session = Session(


### PR DESCRIPTION
**Associated Issue(s):** resolves #76 

### Changes in this PR

- Fixes `concept-eval` recipe by adding a custom session factory and disabling `auto_exclude_current` as suggested by Prodigy support
- Updates changelog

### Notes

- To reproduce the task routing error, it's important to restart the server after one language's session completes the majority of examples. On the restart, the other language session should only be able to access the small number of examples that have not be annotated.
- I recommend using the tiny test dataset I created `debug-task1.jsonl` which contains 5 examples per language for reproducing the error and testing the fix
- To test the fix, `prodigy_recipe_url` needs to be updated to https://raw.githubusercontent.com/Princeton-CDH/muse/refs/heads/hotfix/task-routing-fix/src/muse/annotation/annotation_recipes.py
- I also recommend updating the dataset name `prodigy_dataset` to something not in the test database to avoid encountering any preexisting annotation data. You can see what datasets are in the database by running `prodigy stats -l`

### Reviewer Checklist

- [x] Confirm that annotators are served all examples irrespective of any other annotator's progress
- [x] Confirm that annotators are not re-served examples they've already annotated