### PR TITLE
Add script for building annotation results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## 0.2.0
+
+### Annotation
+
+- `build_report` script for building annotation results from exported Prodigy annotation data
+
 ## 0.1.1
 
 - Update `concept-eval` recipe to fix cross-session filtering error

--- a/src/muse/annotation/annotation_recipes.py
+++ b/src/muse/annotation/annotation_recipes.py
@@ -27,6 +27,8 @@ from prodigy.structured_types import get_input_hash, get_task_hash
 from prodigy.types import PathInputType, RecipeSettingsType, StreamType
 from prodigy.util import INPUT_HASH_ATTR, TASK_HASH_ATTR
 
+from muse.annotation.constants import CONCEPT_EVAL_TYPOLOGY
+
 
 def add_tokens(stream: StreamType) -> Iterator[StreamType]:
     """
@@ -168,15 +170,7 @@ def concept_eval_recipe(
         "Q3. Notes / observations",
     ]
 
-    q2_labels = [
-        {"id": "correct", "text": "Correct translation"},
-        {"id": "translated", "text": "Should not translate"},
-        {"id": "missing", "text": "Omitted or missing"},
-        {"id": "ils", "text": "Incorrect lexical selection"},
-        {"id": "dit", "text": "Disambiguation issue in target"},
-        {"id": "untranslated", "text": "Incorrectly left untranslated"},
-        {"id": "other", "text": "Other error"},
-    ]
+    q2_labels = [{"id": label, "text": text} for label, text in CONCEPT_EVAL_TYPOLOGY]
 
     # Recipe organization
     ## Initial html template for starting text

--- a/src/muse/annotation/build_results.py
+++ b/src/muse/annotation/build_results.py
@@ -1,0 +1,141 @@
+# Copyright Center for Digital Humanities, Princeton University 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+This script is used to convert Prodigy exported annotation data (JSONL) into
+a human-readable spreadsheet (CSV).
+
+Currently supports the following annotation recipes: concept-eval
+
+Example Usage:
+
+    build_results.py concept-eval muse-concepts.jsonl concept-annotations.csv
+"""
+
+import argparse
+import csv
+import pathlib
+import sys
+
+import orjsonl
+
+from muse.annotation.constants import CONCEPT_EVAL_TYPOLOGY
+
+
+def get_span_texts(
+    spans: list[dict[str, int | str]],
+    ref_text: str,
+    trim_ws: bool = True,
+) -> list[str]:
+    """
+    For a list of span annotations, extract their corresponding text from the
+    reference text. Removes leading and trailing whitespace from span texts
+    by default.
+    """
+    span_texts = []
+    for span in spans:
+        span_text = ref_text[span["start"] : span["end"]]
+        if trim_ws:
+            span_text = span_text.strip()
+        span_texts.append(span_text)
+    return span_texts
+
+
+def save_concept_eval_results(dataset: pathlib.Path, out_csv) -> None:
+    """
+    Build the annotation results (CSV) for exported annotations (JSONL)
+    for the concept-eval Prodigy annotation recipe.
+    """
+    fieldnames = [
+        "tr_id",
+        "pair_id",
+        "model",
+        "language",
+        "term",
+        "src_text",
+        "ref_tr",
+        "mt_text",
+        "q1",
+        "q2",
+        "q3",
+        "annotator",
+    ]
+    with out_csv.open(mode="w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for anno in orjsonl.stream(dataset):
+            # Q1's answers are in spans field
+            q1_spans = get_span_texts(anno.get("spans", []), anno["text"])
+            # Q2's answer is in accept field which contains a list with
+            # a single label id
+            q2_type = CONCEPT_EVAL_TYPOLOGY[anno["accept"][0]]
+            # Q3's answer if present is in the user_input field
+            q3_text = anno.get("user_input", "").strip()
+            # session id = "concept-eval-[lang]_[annotator]"
+            annotator = anno["_session_id"].rsplit("_", maxsplit=1)[-1]
+            res_row = {
+                "tr_id": anno["tr_id"],
+                "pair_id": anno["pair_id"],
+                "model": anno["model"],
+                "language": anno["lang_name"],
+                "term": anno["term"],
+                "src_text": anno["src_text"],
+                "ref_tr": anno["ref_text"],
+                "mt_text": anno["text"],
+                "q1": "\n".join(q1_spans),
+                "q2": q2_type,
+                "q3": q3_text,
+                "annotator": annotator,
+            }
+            writer.writerow(res_row)
+
+
+def save_annotation_results(
+    task: str,
+    dataset: pathlib.Path,
+    out_csv: pathlib.Path,
+) -> None:
+    """
+    Build annotation results (CSV) for a given Prodigy task and
+    exported annotations (JSONL).
+    """
+    if task == "concept-eval":
+        save_concept_eval_results(dataset, out_csv)
+    else:
+        raise ValueError(f"Unknown task: {task}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Builds results csv for a given Prodigy annotation recipe and datset export"
+    )
+    parser.add_argument("task", type=str, help="Name of the Prodigy annotation recipe")
+    parser.add_argument(
+        "dataset",
+        type=pathlib.Path,
+        help="Prodigy dataset export (JSONL) of annotations",
+    )
+    parser.add_argument(
+        "output",
+        type=pathlib.Path,
+        help="Output annotation results (CSV)",
+    )
+    parsed = parser.parse_args()
+
+    # Validate args
+    if not parsed.dataset.is_file():
+        print(f"ERROR: {parsed.dataset} does not exist", file=sys.stderr)
+        sys.exit(1)
+    if parsed.output.is_file():
+        print(f"ERROR: {parsed.output} exists. Not overwriting.", file=sys.stderr)
+        sys.exit(1)
+
+    save_annotation_results(
+        parsed.task,
+        parsed.dataset,
+        parsed.output,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/muse/annotation/constants.py
+++ b/src/muse/annotation/constants.py
@@ -1,0 +1,17 @@
+# Copyright Center for Digital Humanities, Princeton University 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Constants used by the annotation submodule
+"""
+
+#: The error typology for the concept-eval task
+CONCEPT_EVAL_TYPOLOGY = {
+    "correct": "Correct translation",
+    "translated": "Should not translate",
+    "missing": "Omitted or missing",
+    "ils": "Incorrect lexical selection",
+    "dit": "Disambiguation issue in target",
+    "untranslated": "Incorrectly left untranslated",
+    "other": "Other error",
+}


### PR DESCRIPTION
**Associated Issue(s):** resolves #83 

### Changes in this PR

- Adds script `annotation/build_results.py` for creating a results CSV from exported annotation data
- Creates a separate file for storing annotation-related constants `constants.py` so that Prodigy-dependent code (i.e., recipes) can be kept separate from other code.
- Update `annotation_recipes.py` to use `constants.py`

### Reviewer Checklist

- [x] Confirm that you can run the script locally. For testing this, use the partially exported annotations from 5/13/26 which are located on TigerData at `cdh/muse/phase-1/prodigy/exports/notion-concepts/muse-concepts-2026-05-13.jsonl`. You can compare your output with [this spreadsheet](https://docs.google.com/spreadsheets/d/1wA892lTiVcnl5aN_EgxQpi7L3_pn4WydMlEVUdcnvQY/edit?gid=0#gid=0).
